### PR TITLE
Ensure that the component includes all the nodes

### DIFF
--- a/react-chosen.js
+++ b/react-chosen.js
@@ -5,7 +5,7 @@ var Chosen = React.createClass({
     $(this.getDOMNode()).trigger('liszt:updated');
   },
   componentDidMount: function() {
-    var select = $(this.getDOMNode()).find("select");
+    var select = $(this.refs.select.getDOMNode());
     $(select)
       .chosen({
         disable_search_threshold: this.props.disableSearchThreshold,
@@ -21,6 +21,6 @@ var Chosen = React.createClass({
     $(this.getDOMNode()).off('liszt:maxselected change');
   },
   render: function() {
-    return React.DOM.div(null,this.transferPropsTo(React.DOM.select(null, this.props.children)));
+    return React.DOM.div(null,this.transferPropsTo(React.DOM.select({ref: "select"}, this.props.children)));
   }
 });


### PR DESCRIPTION
The Chosen plugin creates several sibling nodes when it's initialized. These nodes are not managed by the React component in the current version of the plugin. This fix wraps the select node with a div node to ensure the sibling nodes are garbage collected when the component is unmounted.
