### PR TITLE
Clear the value if it's set to null

### DIFF
--- a/react-chosen.js
+++ b/react-chosen.js
@@ -3,8 +3,15 @@
     displayName: 'Chosen',
 
     componentDidUpdate: function() {
+      var select = $(this.refs.select.getDOMNode());
+
+      // chosen doesn't clear the value attribute if this.props.value is set to null
+      if (!this.props.value) {
+        select.val('');
+      }
+
       // chosen doesn't refresh the options by itself, babysit it
-      $(this.refs.select.getDOMNode()).trigger('chosen:updated');
+      select.trigger('chosen:updated');
     },
 
     handleChange: function(a, b, c) {


### PR DESCRIPTION
Currently, if the value props is set to null, the Chosen select does not clear. This commit fixes that by clearing the value attribute if props.value is falsey.
