### PR TITLE
Make react-chosen AMD compatible

### DIFF
--- a/react-chosen.js
+++ b/react-chosen.js
@@ -1,4 +1,15 @@
-(function(window, React, $) {
+(function (root, factory) {
+
+  if (typeof define === 'function' && define.amd) {
+    define(['react', 'jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory(require('react'), require('jquery'));
+  } else {
+    root.Chosen = factory(root.React, root.jQuery);
+  }
+
+}(this, function (React, $) {
+
   var Chosen = React.createClass({
     displayName: 'Chosen',
 
@@ -50,20 +61,6 @@
     }
   });
 
-  if (typeof module === 'undefined') {
-      window.Chosen = Chosen;
-    } else {
-      // If we're dropping plain script tag, then we can assume Chosen and
-      // jQuery are already loaded. For browserify, however, we need to
-      // `require` the chosen npm module, which has the side-effect of attaching
-      // chosen onto jQuery. Note that due to the nature of the third-party
-      // chosen npm shim, we still need to manually include jQuery at the top
-      // level.
-      require('drmonty-chosen');
-      module.exports = Chosen;
-    }
-})(
-  window,
-  typeof require === 'function' ? require('react') : React,
-  jQuery
-);
+  return Chosen;
+
+}));

--- a/test/change.html
+++ b/test/change.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Document</title>
-  <link rel="stylesheet" href="../bower_components/chosen/public/chosen.css">
+  <link rel="stylesheet" href="../bower_components/chosen/chosen.min.css">
 </head>
 <body>
   <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/chosen/public/chosen.jquery.js"></script>
+  <script src="../bower_components/chosen/chosen.jquery.min.js"></script>
   <script src="../bower_components/react/react.js"></script>
   <script src="../bower_components/react/JSXTransformer.js"></script>
   <script src="../react-chosen.js"></script>

--- a/test/multi.html
+++ b/test/multi.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Document</title>
-  <link rel="stylesheet" href="../bower_components/chosen/public/chosen.css">
+  <link rel="stylesheet" href="../bower_components/chosen/chosen.min.css">
 </head>
 <body>
   <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/chosen/public/chosen.jquery.js"></script>
+  <script src="../bower_components/chosen/chosen.jquery.min.js"></script>
   <script src="../bower_components/react/react.js"></script>
   <script src="../bower_components/react/JSXTransformer.js"></script>
   <script src="../react-chosen.js"></script>

--- a/test/single.html
+++ b/test/single.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Document</title>
-  <link rel="stylesheet" href="../bower_components/chosen/public/chosen.css">
+  <link rel="stylesheet" href="../bower_components/chosen/chosen.min.css">
 </head>
 <body>
   <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/chosen/public/chosen.jquery.js"></script>
+  <script src="../bower_components/chosen/chosen.jquery.min.js"></script>
   <script src="../bower_components/react/react.js"></script>
   <script src="../bower_components/react/JSXTransformer.js"></script>
   <script src="../react-chosen.js"></script>

--- a/test/single_controlled.html
+++ b/test/single_controlled.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Document</title>
-  <link rel="stylesheet" href="../bower_components/chosen/public/chosen.css">
+  <link rel="stylesheet" href="../bower_components/chosen/chosen.min.css">
 </head>
 <body>
   <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/chosen/public/chosen.jquery.js"></script>
+  <script src="../bower_components/chosen/chosen.jquery.min.js"></script>
   <script src="../bower_components/react/react.js"></script>
   <script src="../bower_components/react/JSXTransformer.js"></script>
   <script src="../react-chosen.js"></script>


### PR DESCRIPTION
This change makes it so that react-chosen would be supported by require.js and other AMD-compatible JS loaders.  It's implemented in a way such that existing `module.exports` style exporting will continue to work as well.